### PR TITLE
Avoid usage of deprecated function

### DIFF
--- a/source/lesson04/content.rst
+++ b/source/lesson04/content.rst
@@ -14,7 +14,7 @@ Learning Objectives
 
 * contrast the difference between adding individual points into a ROC plot and producing a ROC curve
 
-* show `plot_roc_curve` in sklearn
+* show `RocCurveDisplay` in sklearn
 
 * discuss extremes of a ROC curve
 

--- a/source/lesson04/script.ipynb
+++ b/source/lesson04/script.ipynb
@@ -553,9 +553,9 @@
     }
    ],
    "source": [
-    "from sklearn.metrics import plot_roc_curve\n",
+    "from sklearn.metrics import RocCurveDisplay\n",
     "\n",
-    "roc = plot_roc_curve(kmeans, X_test, y_test)\n"
+    "roc = RocCurveDisplay.from_estimator(kmeans, X_test, y_test)\n"
    ]
   },
   {


### PR DESCRIPTION
The participants will be using a `scikit-learn` version in which they will get deprecation warnings for the `plot_roc_curve` function, so use the new substitution.

I also looked in the [lesson04 repository](https://github.com/deeplearning540/lesson04) for occurrences but did not find any.