### PR TITLE
Fix missing image dimension

### DIFF
--- a/source/lesson09/content.rst
+++ b/source/lesson09/content.rst
@@ -23,9 +23,10 @@ Check your Learning
 .. code-block:: python
 
    width, height = (32, 32)
+   channels = 3
    n_hidden_neurons = 100
    n_bias = 100
-   n_input_items = width * height
+   n_input_items = width * height * channels
    n_parameters = (n_input_items * n_hidden_neurons) + n_bias
    print(n_parameters)
 


### PR DESCRIPTION
The channel dimension was missing; the printed output of 307300
parameters was correct, though, so only the formula was wrong.